### PR TITLE
Support packages that want to link against DOtherSide statically

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,5 +6,16 @@
     "copyright": "Copyright © 2014-2015 Filippo Cucchetto",
     "authors": ["Filippo Cucchetto"],
     "license": "LGPLv3",
-    "libs": ["DOtherSide"]
+    "configurations": [
+        {
+            "name": "library",
+            "libs": ["DOtherSide"]
+        },
+        {
+            "name": "library-static",
+            "libs": ["DOtherSideStatic",
+                     "Qt5Core", "Qt5Qml", "Qt5Gui", "Qt5Quick", "Qt5Widgets",
+                     "stdc++"]
+        }
+    ]
 }


### PR DESCRIPTION
The problem is simple: Some package "foo" wants to build an executable linking against DOtherSide statically.
Solution: Refactor "libs" into dub-automatically-chosen subconfiguration "library" and add a subconfiguration "library-static" allowing the static linking.

How to use: Below your normal `dependency "dqml" [...]` line, simply add `subConfiguration "dqml" "library-static"`.
